### PR TITLE
Add estimation view dialog with download options

### DIFF
--- a/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
+++ b/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
@@ -7,11 +7,13 @@ import ProcessingIcon from '@mui/icons-material/DirectionsRun';
 import SuccessIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Button } from "@mui/material";
+import { EstimationView } from "../estimation-view/estimation-view";
 
 export const EstimationList: FC = () => {
   const { data: rawEstimations, isFetched } = useEstimations();
   const [estimations, setEstimations] = useState<IEstimation[]>([]);
   const [isDataLoaded, setDataLoad] = useState<boolean>(false);
+  const [selectedEstimation, setSelectedEstimation] = useState<IEstimation | null>(null);
   /*          
            }) */
   const startColumns: GridColDef[] = [
@@ -54,15 +56,17 @@ export const EstimationList: FC = () => {
       renderCell: (params) => {
         return (<>
           <Button
-            onClick={(e) => console.log("tbi")}
+            onClick={(e) => setSelectedEstimation(params.row)}
             variant="contained"
+            disabled={params.row.state !== EstimationState.Success}
           >
             View
           </Button>
           <Button
-            sx={{marginLeft: 1}}
+            sx={{ marginLeft: 1 }}
             onClick={(e) => console.log("tbi")}
             variant="contained"
+            disabled={params.row.state === EstimationState.Processing}
           >
             Delete
           </Button>
@@ -71,10 +75,6 @@ export const EstimationList: FC = () => {
     }
   ];
 
-
-
-
-
   useEffect(() => {
     setEstimations(rawEstimations ?? []);
     setDataLoad(isFetched);
@@ -82,10 +82,10 @@ export const EstimationList: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps 
   }, [rawEstimations]);
 
-
   return (
     <>
-      <DataGrid columnVisibilityModel={{tags:window.innerWidth > 500, modifiedDate: window.innerWidth > 500}} loading={!isDataLoaded} rows={estimations} getRowId={(row: IEstimation) => row.internalGuid} columns={startColumns} />
+      <EstimationView estimation={selectedEstimation} open={selectedEstimation != null} handleClose={() => setSelectedEstimation(null) }/>
+      <DataGrid columnVisibilityModel={{ tags: window.innerWidth > 500, modifiedDate: window.innerWidth > 500 }} loading={!isDataLoaded} rows={estimations} getRowId={(row: IEstimation) => row.internalGuid} columns={startColumns} />
     </>
   );
 };

--- a/src/BffWeb/ClientApp/src/components/estimation-view/estimation-view.tsx
+++ b/src/BffWeb/ClientApp/src/components/estimation-view/estimation-view.tsx
@@ -10,6 +10,7 @@ export const EstimationView: FC<{ estimation: IEstimation | null, open: boolean,
 
     useEffect(() => {
         // load preview when possible
+        setPreviewUrl(undefined);
         if (props.estimation == null) return;
         axios.get(`/api/GetAttachment?estimationId=${props.estimation.internalGuid}&attachmentType=${AttachmentType.Preview}`, { responseType: 'arraybuffer', headers: { 'X-CSRF': '1' } }).then(res => {
             const url = window.URL.createObjectURL(new Blob([res.data]));

--- a/src/BffWeb/ClientApp/src/components/estimation-view/estimation-view.tsx
+++ b/src/BffWeb/ClientApp/src/components/estimation-view/estimation-view.tsx
@@ -1,0 +1,71 @@
+import { FC, useEffect, useState } from "react";
+import { Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
+import { AttachmentType, IEstimation } from "../../helpers/api.types";
+import axios from "axios";
+
+export const EstimationView: FC<{ estimation: IEstimation | null, open: boolean, handleClose: () => void }> = (props) => {
+
+    const [previewUrl, setPreviewUrl] = useState<string | undefined>(undefined);
+
+
+    useEffect(() => {
+        // load preview when possible
+        if (props.estimation == null) return;
+        axios.get(`/api/GetAttachment?estimationId=${props.estimation.internalGuid}&attachmentType=${AttachmentType.Preview}`, { responseType: 'arraybuffer', headers: { 'X-CSRF': '1' } }).then(res => {
+            const url = window.URL.createObjectURL(new Blob([res.data]));
+            setPreviewUrl(url);
+        })
+    }, [props.estimation])
+
+    const download = (estimation: IEstimation | null, type: string) => {
+        if (estimation == null) return;
+
+        // create download for specific attachment type
+        axios.get(`/api/GetAttachment?estimationId=${estimation.internalGuid}&attachmentType=${type}`, { responseType: 'arraybuffer', headers: { 'X-CSRF': '1' } })
+            .then((res) => {
+                const url = window.URL.createObjectURL(new Blob([res.data]));
+                const link = document.createElement('a');
+                link.href = url;
+                var fileName = type === AttachmentType.Joints ? estimation.displayName + '.npz' : estimation.displayName + '.mp4'
+                link.setAttribute('download', fileName); //or any other extension
+                document.body.appendChild(link);
+                link.click();
+            });
+    }
+
+
+    return (
+        <>
+            {props.estimation != null && (
+                <Dialog
+                    open={props.open}
+                    onClose={props.handleClose}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                >
+                    <DialogTitle id="alert-dialog-title">
+                        Estimation: {props.estimation.displayName}
+                    </DialogTitle>
+                    <DialogContent>
+                        <DialogContentText id="alert-dialog-description">
+                            {previewUrl ?(<video autoPlay width={500} loop>
+                                <source src={previewUrl} type="video/mp4" />
+                            </video>) : <CircularProgress/>}
+                        </DialogContentText>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={() => download(props.estimation, AttachmentType.Joints)} autoFocus>
+                            Download Joint Positions
+                        </Button>
+                        <Button onClick={() => download(props.estimation, AttachmentType.Preview)} autoFocus>
+                            Download Preview
+                        </Button>
+                        <Button onClick={props.handleClose} autoFocus>
+                            close
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            )}
+        </>
+    );
+};

--- a/src/BffWeb/ClientApp/src/helpers/api.types.ts
+++ b/src/BffWeb/ClientApp/src/helpers/api.types.ts
@@ -38,3 +38,8 @@ export interface IEstimation {
     state: EstimationState
 }
 
+export enum AttachmentType{
+    Joints = "Joints",
+    Preview ="Preview"
+}
+

--- a/src/BffWeb/ClientApp/src/pages/dashboard/dashboard.tsx
+++ b/src/BffWeb/ClientApp/src/pages/dashboard/dashboard.tsx
@@ -16,7 +16,7 @@ const Dashboard = () => {
   }, [data])
 
   return (
-    <Stack sx={{ height: "90vh" }} direction="column" gap={4} flexWrap="wrap">
+    <Stack sx={{ height: "90vh" }} direction="column" gap={4} flexWrap="nowrap">
       <Stack maxWidth="xl" width={"100%"} marginTop={2} alignSelf={"center"} flexGrow={1} spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
         <Box flexGrow={7} sx={{}}>
           <Typography variant="h5" textAlign={"start"} paddingLeft={3}>
@@ -45,7 +45,7 @@ const Dashboard = () => {
           </Stack>
         </Paper>
       </Stack>
-      <Box maxWidth="xl" width={"100%"} alignSelf={"center"} flexGrow={6} sx={{ width: "100vw" }}>
+      <Box height="xl" maxWidth="xl" width={"100%"} alignSelf={"center"} flexGrow={2} sx={{ width: "100vw" }}>
         <EstimationList />
       </Box>
     </Stack>

--- a/src/BffWeb/Program.cs
+++ b/src/BffWeb/Program.cs
@@ -72,5 +72,7 @@ app.MapRemoteBffApiEndpoint("/api/GetEstimationTest", "https://localhost:" + rem
 app.MapRemoteBffApiEndpoint("/api/GetUserEstimations", "https://localhost:" + remoteApiPort + "/api/Estimation/GetUserEstimations")
           .RequireAccessToken();
 
+app.MapRemoteBffApiEndpoint("/api/GetAttachment", "https://localhost:" + remoteApiPort + "/api/Attachment/GetAttachment")
+          .RequireAccessToken();
 
 app.Run();

--- a/src/Core/Controllers/AttachmentController.cs
+++ b/src/Core/Controllers/AttachmentController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Backend.Controllers
+{
+
+    [ApiController]
+    [Route("api/[controller]/[action]")]
+    public class AttachmentController : ControllerBase
+    {
+
+        private readonly ILogger<AttachmentController> _logger;
+        private readonly IEstimationService _estimationService;
+        private readonly IConfiguration _configuration;
+
+        public AttachmentController(ILogger<AttachmentController> logger, IEstimationService estimationHandler, IConfiguration configuration)
+        {
+            _logger = logger;
+            _estimationService = estimationHandler;
+            _configuration = configuration;
+        }
+        
+        [ActionName("GetAttachment")]
+        [HttpGet(Name = "GetAttachment")]
+        public async Task<IActionResult> Get(string estimationId, AttachmentType attachmentType)
+        {
+            var attachmentFile = _estimationService.GetEstimationAttachment(estimationId, attachmentType);
+
+            if(attachmentFile == null)
+            {
+                return Problem("Couldn't load attachment");
+            }
+
+            var attachmentName = attachmentType == AttachmentType.Joints ? Constants.JOINTS_FILENAME : Constants.PREVIEW_FILENAME;
+            return File(attachmentFile, "application/octet-stream", attachmentName);
+        }
+    }
+}

--- a/src/Core/Models/AttachmentType.cs
+++ b/src/Core/Models/AttachmentType.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AttachmentType
+{
+    Preview,
+    Joints
+}

--- a/src/Core/Models/Constants.cs
+++ b/src/Core/Models/Constants.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+public class Constants
+{
+    public static string JOINTS_FILENAME = "test_man.npz";
+    public static string PREVIEW_FILENAME= "test_man_result.mp4";
+}

--- a/src/Core/Services/IEstimationService.cs
+++ b/src/Core/Services/IEstimationService.cs
@@ -1,8 +1,10 @@
 ﻿
 using Core.Models;
+using Raven.Client.Documents.Attachments;
 
 public interface IEstimationService
 {
     public Estimation HandleUploadedFile(string userGuid, string directory, string fileName, string fileExtension, string displayName, IEnumerable<Tag>? tags);
     public IEnumerable<Estimation> GetAllUserEstimations(string userGuid);
+    public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType);
 }


### PR DESCRIPTION
- adds options for following downloads
  - joint positions
  - preview video
- add preview (not streamed but with small videos the load time is barely noticeable)
- backend introduction of constants for Attachments
- added attachments endpoint 
- fixed a little issues that was caused by too many estimations in the datagrid
