### PR TITLE
Add delete button for estimations

### DIFF
--- a/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
+++ b/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
@@ -8,9 +8,10 @@ import SuccessIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Button } from "@mui/material";
 import { EstimationView } from "../estimation-view/estimation-view";
+import axios from "axios";
 
 export const EstimationList: FC = () => {
-  const { data: rawEstimations, isFetched } = useEstimations();
+  const { data: rawEstimations, isFetched, refetch } = useEstimations();
   const [estimations, setEstimations] = useState<IEstimation[]>([]);
   const [isDataLoaded, setDataLoad] = useState<boolean>(false);
   const [selectedEstimation, setSelectedEstimation] = useState<IEstimation | null>(null);
@@ -64,7 +65,11 @@ export const EstimationList: FC = () => {
           </Button>
           <Button
             sx={{ marginLeft: 1 }}
-            onClick={(e) => console.log("tbi")}
+            onClick={(e) => axios.delete(`/api/DeleteEstimation?estimationId=${params.row.internalGuid}`, { headers: { 'X-CSRF': '1' } }).then(res =>{
+              if(res.status === 200){
+                refetch();
+              }
+            })}
             variant="contained"
             disabled={params.row.state === EstimationState.Processing}
           >

--- a/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
+++ b/src/BffWeb/ClientApp/src/components/estimation-list/estimation-list.tsx
@@ -71,7 +71,6 @@ export const EstimationList: FC = () => {
               }
             })}
             variant="contained"
-            disabled={params.row.state === EstimationState.Processing}
           >
             Delete
           </Button>

--- a/src/BffWeb/ClientApp/src/components/upload-button/upload-button.tsx
+++ b/src/BffWeb/ClientApp/src/components/upload-button/upload-button.tsx
@@ -2,9 +2,11 @@ import { BaseSyntheticEvent, FC, useState } from "react";
 import { Alert, Backdrop, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fab, ListItemText, MenuItem, Select, SelectChangeEvent, Snackbar, Stack, TextField, Typography } from "@mui/material";
 import axios from "axios";
 import NavigationIcon from '@mui/icons-material/Navigation';
+import useEstimations from "../../helpers/estimations";
 
 export const UploadButton: FC = () => {
 
+    const { refetch } = useEstimations();
     const [openUpoadDialog, setOpenUploadDialog] = useState(false);
 
     const handleClickOpen = () => {
@@ -81,6 +83,7 @@ export const UploadButton: FC = () => {
 
         //setValue("thumbnail", res.data.url);
         setTimeout(() => setIsUploading(false), 200);
+        refetch();
     };
 
     return (

--- a/src/BffWeb/ClientApp/src/helpers/estimations.ts
+++ b/src/BffWeb/ClientApp/src/helpers/estimations.ts
@@ -22,9 +22,9 @@ function useEstimations() {
     claimsKeys.claim,
     async () => fetchData(),
     {
-      staleTime: Infinity,
-      cacheTime: Infinity,
-      retry: false
+      staleTime: 20000, // 20 seconds
+      cacheTime: 60000, // 1 minute
+      retry: true
     }
   )
 }

--- a/src/BffWeb/Program.cs
+++ b/src/BffWeb/Program.cs
@@ -81,5 +81,8 @@ app.MapRemoteBffApiEndpoint("/api/Identity/GetIdToken", "https://localhost:" + r
 app.MapRemoteBffApiEndpoint("/api/PostUpload", "https://localhost:" + remoteApiPort + "/api/Upload/PostUpload")
           .RequireAccessToken();
 
+app.MapRemoteBffApiEndpoint("/api/DeleteEstimation", "https://localhost:" + remoteApiPort + "/api/Estimation/DeleteEstimation")
+          .RequireAccessToken();
+
 app.Run();
 

--- a/src/Core/Controllers/EstimationController.cs
+++ b/src/Core/Controllers/EstimationController.cs
@@ -58,6 +58,21 @@ namespace Backend.Controllers
             }
         }
 
+        [ActionName("DeleteEstimation")]
+        [HttpDelete(Name = "DeleteEstimation")]
+        public ActionResult<bool> DeleteEstimation(string estimationId)
+        {
+            try
+            {
+                _estimationHandler.DeleteEstimation(estimationId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                return Problem($"A problem occured when trying to delete estimation:{ex}");
+            }
+        }
+
         // ---- only for testing purposes ----
 
         [ActionName("GetEstimationTest")]

--- a/src/Core/Services/EstimationService.cs
+++ b/src/Core/Services/EstimationService.cs
@@ -107,6 +107,21 @@ namespace Core.Services
             }
         }
 
+        public void DeleteEstimation(string estimationid)
+        {
+            using (var session = _store.OpenSession())
+            {
+                var estimation = session.Query<Estimation>().Where(x => x.InternalGuid == estimationid).FirstOrDefault();
+                if (estimation == null)
+                {
+                    throw new Exception("Estimation could not be found");
+                }
+
+                session.Delete(estimation);
+                session.SaveChanges();
+            }
+        }
+
         //todo make this async?
         private void RunEstimation(string userGuid, string directory, string fileName, string fileExtension)
         {

--- a/src/Core/Services/EstimationService.cs
+++ b/src/Core/Services/EstimationService.cs
@@ -1,10 +1,6 @@
 ﻿using Core.Models;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Attachments;
-using Raven.Client.Documents.Operations.OngoingTasks;
-using System;
 using System.Diagnostics;
-using System.IO;
 
 namespace Core.Services
 {
@@ -38,7 +34,7 @@ namespace Core.Services
 
             using (var session = _store.OpenSession())
             {
-                estimation = new()
+                estimation = new Estimation()
                 {
                     InternalGuid = guid,
                     DisplayName = displayName,
@@ -73,7 +69,7 @@ namespace Core.Services
             }
             try
             {
-                RunEstimation(userGuid, directory, fileName, fileExtension);
+                RunEstimation(userGuid, directory, fileName, fileExtension, estimation.InternalGuid);
             }
             catch
             {
@@ -117,13 +113,22 @@ namespace Core.Services
                     throw new Exception("Estimation could not be found");
                 }
 
+                var processes = RunningProcesses.Where(x => x.Key.Equals(estimationid)).ToList();
+
+                if(processes.Any())
+                {
+                    foreach(var process in processes) {
+                        if (process.Value != null) process.Value.Kill(true);
+                    }
+                }
+
                 session.Delete(estimation);
                 session.SaveChanges();
             }
         }
 
         //todo make this async?
-        private void RunEstimation(string userGuid, string directory, string fileName, string fileExtension)
+        private void RunEstimation(string userGuid, string directory, string fileName, string fileExtension, string estimationGuid)
         {
             int totalFrames = 0;
             string? estimationScriptLocation = _configuration["EstimationScriptLocation"];
@@ -169,7 +174,9 @@ namespace Core.Services
             estimationProcess.Start();
             estimationProcess.BeginOutputReadLine();
             estimationProcess.BeginErrorReadLine();
+            RunningProcesses.Add(estimationGuid, estimationProcess);
             estimationProcess.WaitForExit();
+            RunningProcesses.Remove(estimationGuid);
 
             if (exception != null)
             {

--- a/src/Core/Services/IEstimationService.cs
+++ b/src/Core/Services/IEstimationService.cs
@@ -7,4 +7,5 @@ public interface IEstimationService
     public Estimation HandleUploadedFile(string userGuid, string directory, string fileName, string fileExtension, string displayName, IEnumerable<string> tags);
     public IEnumerable<Estimation> GetAllUserEstimations(string userGuid);
     public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType);
+    public void DeleteEstimation(string estimationid);
 }


### PR DESCRIPTION
Added delete button to grid so that estimations can be deleted.
For in-process estimations it kills all processes related to that estimation -> might lead to follow up except but that doesn't matter since we cleaned up the db at this point (logging might be a bit difficult to read and could be improved in the future)
Also enabled cacheTime of 1 minute so that the grid updates after 1 minute and made force refetch after uploading an estimation.