### PR TITLE
Update default ports to match dockerized id server

### DIFF
--- a/src/BffWeb/Program.cs
+++ b/src/BffWeb/Program.cs
@@ -24,7 +24,7 @@ builder.Services.AddAuthentication(options =>
 })
 .AddOpenIdConnect("oidc", options =>
 {
-    options.Authority = "https://localhost:5001/";
+    options.Authority = "https://localhost:8001/";
     options.ClientId = "PoseifyBff";
     options.ClientSecret = "secret";
     options.ResponseType = "code";

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -23,7 +23,7 @@ builder.Services.AddProblemDetails();
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = "https://localhost:5001";
+        options.Authority = "https://localhost:8001";
         //options.Audience = "https://localhost:44462";
         options.TokenValidationParameters.ValidateAudience = false;
     });


### PR DESCRIPTION
We now have support for dockerized identity server (which should also be used for local development). They run on a different port than running the identity server via vs studio. (We want an error if a developer runs the identity server via vs studio instead of the docker image we provide.