### PR TITLE
Add user check to endpoints

### DIFF
--- a/src/BffWeb/Program.cs
+++ b/src/BffWeb/Program.cs
@@ -66,8 +66,6 @@ app.MapBffManagementEndpoints();
 
 
 int remoteApiPort = 7236;
-app.MapRemoteBffApiEndpoint("/api/GetEstimationTest", "https://localhost:" + remoteApiPort + "/api/Estimation/GetEstimationTest")
-          .RequireAccessToken(Duende.Bff.TokenType.User);
 
 app.MapRemoteBffApiEndpoint("/api/GetUserEstimations", "https://localhost:" + remoteApiPort + "/api/Estimation/GetUserEstimations")
           .RequireAccessToken(Duende.Bff.TokenType.User);
@@ -75,9 +73,6 @@ app.MapRemoteBffApiEndpoint("/api/GetUserEstimations", "https://localhost:" + re
 app.MapRemoteBffApiEndpoint("/api/GetAttachment", "https://localhost:" + remoteApiPort + "/api/Attachment/GetAttachment")
           .RequireAccessToken(Duende.Bff.TokenType.User);
           
-app.MapRemoteBffApiEndpoint("/api/Identity/GetIdToken", "https://localhost:" + remoteApiPort + "/api/Identity/GetIdToken")
-          .RequireAccessToken(Duende.Bff.TokenType.User);
-
 app.MapRemoteBffApiEndpoint("/api/PostUpload", "https://localhost:" + remoteApiPort + "/api/Upload/PostUpload")
           .RequireAccessToken();
 

--- a/src/Core/Controllers/AttachmentController.cs
+++ b/src/Core/Controllers/AttachmentController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace Backend.Controllers
 {
@@ -23,7 +24,15 @@ namespace Backend.Controllers
         [HttpGet(Name = "GetAttachment")]
         public async Task<IActionResult> Get(string estimationId, AttachmentType attachmentType)
         {
-            var attachmentFile = _estimationService.GetEstimationAttachment(estimationId, attachmentType);
+
+            var username = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (username == null)
+            {
+                return Problem("Missing username, probably not logged in");
+            }
+
+            var attachmentFile = _estimationService.GetEstimationAttachment(estimationId, attachmentType, username);
 
             if (attachmentFile == null)
             {

--- a/src/Core/Controllers/UploadController.cs
+++ b/src/Core/Controllers/UploadController.cs
@@ -1,5 +1,6 @@
 using Core.Models;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace Backend.Controllers
 {
@@ -32,10 +33,17 @@ namespace Backend.Controllers
                 return Problem("Missing Upload File");
             }
 
+            var username = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if(username == null)
+            {
+                return Problem("Missing username, probably not logged in");
+            }
+
             var file = uploadModel.FormFile;
 
             string? directory = _configuration["UploadDirectory"];
-            string userGuid = "DEEZNUZ";
+            string userGuid = username;
             string uniqueFilename = Guid.NewGuid().ToString();
             string fileExtension = System.IO.Path.GetExtension(file.FileName);
 
@@ -58,6 +66,9 @@ namespace Backend.Controllers
 
             if (file.Length > 0)
             {
+
+                System.IO.Directory.CreateDirectory($"{directory}\\{userGuid}");
+
                 string fileLocation = $"{directory}\\{userGuid}\\{uniqueFilename}{fileExtension}";
 
                 using (var stream = System.IO.File.Create(fileLocation))

--- a/src/Core/Services/EstimationService.cs
+++ b/src/Core/Services/EstimationService.cs
@@ -86,11 +86,11 @@ namespace Core.Services
             return estimation;
         }
 
-        public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType)
+        public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType, string userGuid)
         {
             using (var session = _store.OpenSession())
             {
-                var estimation = session.Query<Estimation>().Where(x => x.InternalGuid == estimationid).FirstOrDefault();
+                var estimation = session.Query<Estimation>().Where(x => x.InternalGuid == estimationid && x.UploadingProfile == userGuid).FirstOrDefault();
                 if(estimation == null)
                 {
                     throw new Exception("Estimation could not be found");
@@ -102,11 +102,11 @@ namespace Core.Services
             }
         }
 
-        public void DeleteEstimation(string estimationid)
+        public void DeleteEstimation(string estimationid, string userGuid)
         {
             using (var session = _store.OpenSession())
             {
-                var estimation = session.Query<Estimation>().Where(x => x.InternalGuid == estimationid).FirstOrDefault();
+                var estimation = session.Query<Estimation>().Where(x => x.InternalGuid == estimationid && x.UploadingProfile == userGuid).FirstOrDefault();
                 if (estimation == null)
                 {
                     throw new Exception("Estimation could not be found");

--- a/src/Core/Services/IEstimationService.cs
+++ b/src/Core/Services/IEstimationService.cs
@@ -6,6 +6,6 @@ public interface IEstimationService
 {
     public Estimation HandleUploadedFile(string userGuid, string directory, string fileName, string fileExtension, string displayName, IEnumerable<string> tags);
     public IEnumerable<Estimation> GetAllUserEstimations(string userGuid);
-    public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType);
-    public void DeleteEstimation(string estimationid);
+    public Stream? GetEstimationAttachment(string estimationid, AttachmentType attachmentType, string userGuid);
+    public void DeleteEstimation(string estimationid, string userGuid);
 }


### PR DESCRIPTION
Users can now only access data in ravendb which is also assigned to them via UploadProfile.
Since this id is stored in the HTTP-only cookie, forgery can't happen.

Also had to make some logic changes which create folders on the fly.