### PR TITLE
Integrate mobile client for authentication

### DIFF
--- a/src/BffWeb/BffWeb.csproj
+++ b/src/BffWeb/BffWeb.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Duende.BFF" Version="2.0.0" />
     <PackageReference Include="Duende.BFF.Yarp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.1.32" />

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddProblemDetails();
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = "https://localhost:8001";
+        options.Authority = "https://identity.poseify.ngrok.app/";
         //options.Audience = "https://localhost:44462";
         options.TokenValidationParameters.ValidateAudience = false;
     });
@@ -65,5 +65,15 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers().RequireAuthorization("ApiScope");
+
+app.Use(async (context, next) =>
+{
+    if (context.Request.Headers.TryGetValue("Authorization", out var authHeader))
+    {
+        // This helps for devs to track if the authHeader has been forwarded
+        Console.WriteLine($"Authorization Header: {authHeader}");
+    }
+    await next();
+});
 
 app.Run();


### PR DESCRIPTION
It relies on having the mobile client in the IdentityServer.
With the help of AccessToken, this PR allows the mobile app to access the BFF when the user is authenticated.
This was needed due to mobile apps being significantly different than a web client aka not being able to have httpOnly cookies.